### PR TITLE
Fix background assets missing in Pillars section

### DIFF
--- a/src/components/landing/PillarsSection/Background.tsx
+++ b/src/components/landing/PillarsSection/Background.tsx
@@ -109,7 +109,7 @@ const Background = ({ sectionRef }: Props) => {
           css={backgroundImageStyles}
           placeholder="blurred"
           layout="fullWidth"
-          src="../../images/ba-illus.jpg"
+          src="../../../images/ba-illus.jpg"
           alt="illustration"
         />
       </BackgroundAnimation>
@@ -123,7 +123,7 @@ const Background = ({ sectionRef }: Props) => {
           formats={['png']}
           height={200}
           width={300}
-          src="../../images/ba-logo-mini-white.png"
+          src="../../../images/ba-logo-mini-white.png"
           alt="logo"
         />
       </LogoAnimation>


### PR DESCRIPTION
• Fixed the incorrect image file paths

| Before | After |
| --- | --- |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/17793151/164687547-7aebec74-5420-4588-bbad-f9fe048c8376.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/17793151/164687103-4c2b765d-a0a3-42b3-857f-3896a66d0496.png"> |
