### PR TITLE
Add missing site metadata in gatsby config

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -6,6 +6,11 @@ const siteDescription =
 const siteUrl = 'https://www.bayungangeles.org'
 
 const config: GatsbyConfig = {
+  siteMetadata: {
+    title: siteTitle,
+    description: siteDescription,
+    siteUrl,
+  },
   plugins: [
     'gatsby-plugin-emotion',
     'gatsby-plugin-image',


### PR DESCRIPTION
Fixes [`gatsby-plugin-sitemap`](https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference) error caused by missing `siteUrl` in gatsby config.